### PR TITLE
removed a vestigial file called .eslintrc.json and added its contents to .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,8 +8,6 @@ module.exports = {
     'eslint:recommended',
     'plugin:react/recommended',
     'next/core-web-vitals'
-    };
-    
   ],
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,7 @@ module.exports = {
     semi: [
       'error',
       'never'
-    ]
+    ],
+    complexity: ['warn', 10]
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,10 @@ module.exports = {
   },
   extends: [
     'eslint:recommended',
-    'plugin:react/recommended'
+    'plugin:react/recommended',
+    'next/core-web-vitals'
+    };
+    
   ],
   overrides: [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}


### PR DESCRIPTION
The next/core-web-vitals was not being used because the eslintrc.js file has precedent over the (now deleted) eslintrc.json file. 